### PR TITLE
Mark explicit nullable type as required by PHP 8.4

### DIFF
--- a/lib/Api/IssuedDocumentsApi.php
+++ b/lib/Api/IssuedDocumentsApi.php
@@ -123,9 +123,9 @@ class IssuedDocumentsApi
      * @param int             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -487,7 +487,7 @@ class Configuration
     * @param array|null $variables    hash of variable and the corresponding value (optional)
     * @return string URL based on host settings
     */
-    public static function getHostString(array $hostSettings, $hostIndex, array $variables = null)
+    public static function getHostString(array $hostSettings, $hostIndex, ?array $variables = null)
     {
         if (null === $variables) {
             $variables = [];


### PR DESCRIPTION
As per title, this PR fixes a few warnings thrown in PHP 8.4, as it requires all nullable arguments to be explictly nullable